### PR TITLE
Fix lightsim2grid.grid_model.init import in OptimCVXPY

### DIFF
--- a/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
+++ b/l2rpn_baselines/OptimCVXPY/optimCVXPY.py
@@ -20,7 +20,15 @@ from grid2op.Action import ActionSpace, BaseAction
 from grid2op.Backend import PandaPowerBackend
 from grid2op.Observation import BaseObservation
 from lightsim2grid import LightSimBackend
-from lightsim2grid.gridmodel import init
+
+from importlib.metadata import version as version_str
+from packaging import version
+lightsim2grid_version = version.parse(version_str("lightsim2grid"))
+
+if lightsim2grid_version >= version.parse("0.9.1"):
+    from lightsim2grid.gridmodel import init_from_pandapower as init
+else:
+    from lightsim2grid.gridmodel import init
 
 import pdb
 


### PR DESCRIPTION
WIth new LightSim2Grid versions, in `lightsim2grid.grid_model`, `init` is replaced with `init_from_pandapower`. The `init` function was used by the `OptimCVXPY` agent, so an error was raised with too recent versions of LightSim2grid.
In this PR, I check the LightSim2Grid version and then I import the corresponding function.